### PR TITLE
Fix interface dropdown component names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ export default {
 					"code",
 					"image",
 					"paragraph",
-					"delimeter",
+					"delimiter",
 					"checklist",
 					"quote",
 					"underline"

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export default {
 			type: "string",
 			meta: {
 				width: "half",
-				interface: "dropdown",
+				interface: "select-dropdown",
 				options: {
 					choices: [
 						{ text: "sans-serif", value: "sans-serif" },
@@ -55,7 +55,7 @@ export default {
 			},
 			meta: {
 				width: "half",
-				interface: "dropdown-multiselect",
+				interface: "select-multiple-dropdown",
 				options: {
 					choices: [
 						{ value: "header", text: "Header" },

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -73,7 +73,7 @@ export default {
 				"code",
 				"image",
 				"paragraph",
-				"delimeter",
+				"delimiter",
 				"checklist",
 				"quote",
 				"underline"


### PR DESCRIPTION
I noticed that the interface dropdowns for font and tools do not work in the latest Directus v9 versions.

This change converts `dropdown` to `select-dropdown` and `dropdown-multiselect` to `select-multiple-dropdown`.

It also fixes a typo with `delimeter` instead of `delimiter`

I haven't generated the dist version of the extension as with recent package update, some extra dependencies may be needed.