### PR TITLE
Fixes multiple blocks delete issue

### DIFF
--- a/src/interface.vue
+++ b/src/interface.vue
@@ -36,6 +36,7 @@ import useDirectusToken from './use-directus-token';
 import useFileHandler from './use-filehandler';
 import useTools from './use-tools';
 import getTranslations from './translations';
+import { wait } from './wait';
 
 export default defineComponent({
 	props: {
@@ -174,6 +175,8 @@ export default defineComponent({
 			isInternalChange.value = true;
 
 			try {
+				// Fixes deleting multiple blocks bug https://github.com/codex-team/editor.js/issues/1755#issuecomment-929550729
+				await wait(200);
 				const result: EditorJS.OutputData = await context.saver.save();
 
 				if (!result || result.blocks.length < 1) {

--- a/src/wait.ts
+++ b/src/wait.ts
@@ -1,0 +1,3 @@
+export async function wait(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
There is an known issue in Editor.js where deleting multiple blocks deletes only one of them. For more details see here: https://github.com/codex-team/editor.js/issues/1755#issuecomment-929550729

Closes https://github.com/dimitrov-adrian/directus-extension-editorjs-interface/issues/28